### PR TITLE
Add support for M1 macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ require("protoc-binary").version;
 
 See official [protoc binaries](https://api.github.com/repos/protocolbuffers/protobuf/releases/latest) download page.
 
+* osx-aarch_64.zip
 * osx-x86_64.zip
 * linux-x86_32.zip
 * linux-x86_64.zip

--- a/consts.js
+++ b/consts.js
@@ -1,6 +1,7 @@
 const path = require("path");
 
 const binaryZip = {
+    "darwin-arm64": "aarch_64.zip",
     "darwin-x64": "osx-x86_64.zip",
     "linux-x32": "linux-x86_32.zip",
     "linux-x64": "linux-x86_64.zip",

--- a/consts.js
+++ b/consts.js
@@ -1,7 +1,7 @@
 const path = require("path");
 
 const binaryZip = {
-    "darwin-arm64": "aarch_64.zip",
+    "darwin-arm64": "osx-aarch_64.zip",
     "darwin-x64": "osx-x86_64.zip",
     "linux-x32": "linux-x86_32.zip",
     "linux-x64": "linux-x86_64.zip",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "protoc",
         "binary"
     ],
-    "version": "1.1.1",
+    "version": "1.2.0",
     "author": "vallyien@gmail.com",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
Adds support for M1 macs.
Currently I see this error:

```
error /path/node_modules/protoc-binary: Command failed.
Exit code: 1
Command: node install
Arguments:
Directory: /path/node_modules/protoc-binary
Output:
/path/node_modules/protoc-binary/install.js:12
        throw Error(`${process.platform}-${process.arch} unsupported`)
              ^

Error: darwin-arm64 unsupported
    at install (/path/node_modules/protoc-binary/install.js:12:15)
    at Object.<anonymous> (/path/node_modules/protoc-binary/install.js:35:3)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

So I went to the latest release https://api.github.com/repos/protocolbuffers/protobuf/releases/latest
And found the release for M1 Macs.