### PR TITLE
Add support to linux arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ See official [protoc binaries](https://api.github.com/repos/protocolbuffers/prot
 * osx-x86_64.zip
 * linux-x86_32.zip
 * linux-x86_64.zip
+* linux-arm64.zip
 * win32.zip
 * win64.zip

--- a/consts.js
+++ b/consts.js
@@ -5,6 +5,7 @@ const binaryZip = {
     "darwin-x64": "osx-x86_64.zip",
     "linux-x32": "linux-x86_32.zip",
     "linux-x64": "linux-x86_64.zip",
+    "linux-arm64": "linux-aarch_64.zip",
     "win32-x32": "win32.zip",
     "win32-x64": "win64.zip"
 }[process.platform + "-" + process.arch];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "protoc",
         "binary"
     ],
-    "version": "1.2.0",
+    "version": "1.3.0",
     "author": "vallyian@gmail.com",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
Adding support for linux on arm processors. 

This is a follow-up to https://github.com/vallyian/protoc-binary/pull/2
After I made sure that it works as expected on my Mac I realized that it still does not work in docker environments where we use linux as a base image.

The current output is:
```
#0 22.31 Output:
#0 22.31 /service/node_modules/protoc-binary/install.js:12
#0 22.31         throw Error(`${process.platform}-${process.arch} unsupported`)
#0 22.31               ^
#0 22.31
#0 22.31 Error: linux-arm64 unsupported
#0 22.31     at install (/service/node_modules/protoc-binary/install.js:12:15)
```

